### PR TITLE
Dependency Package updates and minor code mods to allow build on iOS 14+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ ClientBin/
 *.jfm
 *.pfx
 *.publishsettings
+*.DS_Store
 node_modules/
 orleans.codegen.cs
 

--- a/WLED/WLED.iOS/WLED.iOS.csproj
+++ b/WLED/WLED.iOS/WLED.iOS.csproj
@@ -28,6 +28,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignProvision>VS: WildCard Development</CodesignProvision>
     <CodesignKey>iPhone Developer: Christian Schwinne (K7LH967W38)</CodesignKey>
   </PropertyGroup>
@@ -57,6 +58,7 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignProvision>VS: WildCard Development</CodesignProvision>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -68,6 +70,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer: Christian Schwinne (K7LH967W38)</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
     <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
@@ -82,6 +85,7 @@
     <CodesignProvision>VS: WildCard Development</CodesignProvision>
     <CodesignKey>iPhone Developer: Christian Schwinne (K7LH967W38)</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>none</DebugType>
@@ -95,6 +99,7 @@
     <CodesignKey>iPhone Distribution: Christian Schwinne (A64W9L8Q44)</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -315,9 +320,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.0.0</Version>
+      <Version>1.6.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1009999" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/WLED/WLED/DeviceListViewPage.xaml.cs
+++ b/WLED/WLED/DeviceListViewPage.xaml.cs
@@ -115,7 +115,7 @@ namespace WLED
             if (deviceList.Remove(d)) InsertDeviceSorted(d);
         }
 
-        private void OnPowerButtonTapped(object sender, ItemTappedEventArgs e)
+        private void OnPowerButtonTapped(object sender, EventArgs e)
         {
             Button s = sender as Button;
             if (s.Parent.BindingContext is WLEDDevice targetDevice)

--- a/WLED/WLED/DeviceModificationListViewPage.xaml.cs
+++ b/WLED/WLED/DeviceModificationListViewPage.xaml.cs
@@ -23,7 +23,7 @@ namespace WLED
             DeviceModificationListView.ItemsSource = DeviceList;
         }
 
-        private void OnDeleteButtonTapped(object sender, ItemTappedEventArgs e)
+        private void OnDeleteButtonTapped(object sender, EventArgs e)
         {
             Button s = sender as Button;
             if (!(s.Parent.BindingContext is WLEDDevice targetDevice)) return;

--- a/WLED/WLED/MenuBar.xaml
+++ b/WLED/WLED/MenuBar.xaml
@@ -26,17 +26,17 @@
                 <ColumnDefinition Width="*"  />
                 <ColumnDefinition Width="65" />
             </Grid.ColumnDefinitions>
-            <Image x:Name="imageLeft" Source="icon_back.png" Style="StaticResource{MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="0">
+            <Image x:Name="imageLeft" Source="icon_back.png" Style="{StaticResource MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="0">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnLeftButtonTapped" />
                 </Image.GestureRecognizers>
             </Image>
-            <Image Source="wled_logo.png" Style="StaticResource{MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="1">
+            <Image Source="wled_logo.png" Style="{StaticResource MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="1">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnLogoTapped" />
                 </Image.GestureRecognizers>
             </Image>
-            <Image x:Name="imageRight" Style="StaticResource{MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="2">
+            <Image x:Name="imageRight" Style="{StaticResource MenuBarButtonStyle}" BackgroundColor="#333" Grid.Column="2">
                 <Image.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnRightButtonTapped" />
                 </Image.GestureRecognizers>

--- a/WLED/WLED/MenuBar.xaml.cs
+++ b/WLED/WLED/MenuBar.xaml.cs
@@ -44,12 +44,18 @@ namespace WLED
             }
         }
 
-        void OnLogoTapped(object sender, ItemTappedEventArgs e)
+        void OnLogoTapped(object sender, EventArgs e)
         {
             Device.OpenUri(new Uri("https://github.com/Aircoookie/WLED"));
         }
 
-        protected virtual void OnLeftButtonTapped(object sender, ItemTappedEventArgs e)
+        //Will be needed for future releases as Device.OpenUri is deprecated
+        //async Task OnLogoTapped(object sender, EventArgs e)
+        //{
+        //    Browser.OpenAsync(new Uri("https://github.com/Aircoookie/WLED"), BrowserLaunchMode.SystemPreferred);
+        //}
+
+        protected virtual void OnLeftButtonTapped(object sender, EventArgs e)
         {
             EventHandler handler = LeftButtonTapped;
             if (handler != null)
@@ -62,7 +68,7 @@ namespace WLED
             }
         }
 
-        protected virtual void OnRightButtonTapped(object sender, ItemTappedEventArgs e)
+        protected virtual void OnRightButtonTapped(object sender, EventArgs e)
         {
             RightButtonTapped?.Invoke(this, e);
         }

--- a/WLED/WLED/WLED.csproj
+++ b/WLED/WLED/WLED.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tmds.MDns" Version="0.7.0" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1009999" />
+    <PackageReference Include="Tmds.MDns" Version="0.7.1" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,8 +43,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Xamarin.iOS">
-      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\12.14.0.110\lib\mono\Xamarin.iOS\Xamarin.iOS.dll</HintPath>
-    </Reference>
+    <None Remove=".DS_Store" />
   </ItemGroup>
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
-<a href='https://play.google.com/store/apps/details?id=com.aircoookie.WLED&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80" align="middle"/></a>
-<a href='https://apps.apple.com/us/app/wled/id1475695033'><img alt='Download on the App Store' src='https://raw.githubusercontent.com/Aircoookie/WLED-App/master/StoreImages/appstore_badge.svg?sanitize=true' height="55" align="middle"/></a>
+<a href="https://play.google.com/store/apps/details?id=com.aircoookie.WLED&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"><img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="80" align="middle"/></a>
+<a href="https://apps.apple.com/us/app/wled/id1475695033"><img alt="Download on the Apple App Store" src="https://raw.githubusercontent.com/Aircoookie/WLED-App/master/StoreImages/appstore_badge.svg?sanitize=true" height="55" align="middle"/></a>
 
-## Welcome to the WLED app! (v1.0.3)
+## Welcome to the WLED app! (v1.0.4)
 
-A brand new app for Android, iPhone, iPad and UWP devices for discovering and controlling your [WLED](https://github.com/Aircoookie/WLED) devices easily!
+An app for Android, iPhone, iPad and UWP devices for discovering and controlling a [WLED](https://github.com/Aircoookie/WLED) devices easily!
 
 ### Features:
 - Automatic device detection (mDNS)
@@ -15,24 +15,33 @@ A brand new app for Android, iPhone, iPad and UWP devices for discovering and co
 
 #### My WLED lights are not found!
 
-Ensure your phone/device is in the same network as the ESP.  
-The "mDNS address" WiFi settings entry in WLED must be unique for every device.  
-Try restarting both the ESP and your device.  
-Attempt manually adding the device via its IP.
+1. Ensure your phone/device is in the same network as the ESP.
+1. The "mDNS address" WiFi settings entry in WLED must be unique for every device.
+1. Try restarting both the ESP and your device.
+1. Attempt manually adding the device via its IP address.
 
 #### Can I control the lights when I'm not home?
 
-In the default configuration this is not possible, the devices need to be in the same local network.  
-However, you can either use a VPN to connect to your home network (if your router offers this option) or use a [port forwarding](https://github.com/Aircoookie/WLED/wiki/Remote-Access-and-IFTTT).  
-Keep in mind that this exposes your light(s) to the public internet, so please be aware that it is not a secure solution.  
-If you want to risk it, at least take the precaution of enabling the WLED [OTA lock](https://github.com/Aircoookie/WLED/wiki/Security) feature and, if possible, only connect it to a guest network.  
+In the default configuration this is not possible, the devices need to be in the same local network.
+However, you can either use a VPN to connect to your home network (if your router offers this option) or use a [port forwarding](https://github.com/Aircoookie/WLED/wiki/Remote-Access-and-IFTTT).
+Keep in mind that this exposes your light(s) to the public internet, so please be aware that it is not a secure solution.
+If you want to risk it, at least take the precaution of enabling the WLED [OTA lock](https://github.com/Aircoookie/WLED/wiki/Security) feature and, if possible, only connect it to a guest network.
 
 #### Where can I get the UWP app?
 
-Right now my primary goal is Android support.  
+Right now my primary goal is Android support.
 The UWP platform is tested and confirmed to work, but right now you need to install Xamarin.Forms for Visual Studio and build it yourself.
 In the future, I will look into ways of distributing the UWP binaries via appstores or releases.
 
-Google Play and the Google Play logo are trademarks of Google LLC.   
+## Contribute
+
+### Requirements
+
+- [Visual Studio](https://visualstudio.microsoft.com/)
+- [Visual Studio Tools for Xamarin](https://visualstudio.microsoft.com/xamarin/)
+
+### Trademarks
+
+Google Play and the Google Play logo are trademarks of Google LLC.
 
 Apple, the Apple logo, iPhone, and iPad are trademarks of Apple Inc., registered in the U.S. and other countries and regions. App Store is a service mark of Apple Inc.


### PR DESCRIPTION
On iOS 14 the app would crash when tapping the `+` button (making the app very unusable [unless you'd set up a connection to your lights running the app on a previous version of iOS).

Buy using newer Package versions (and some small code syntax mods) I was able to build the app using Visual Studio Community 2019 for Mac (Preview) Version 8.10 Preview (8.10 build 1759) on macOS Big Sur (v 11.3.1) and Ad-Hoc Distribute to my iPhone 12 Mini and test on both iOS 14.5.1.